### PR TITLE
Overview Dashboard Resources Reports

### DIFF
--- a/default/data/ui/views/overview.xml
+++ b/default/data/ui/views/overview.xml
@@ -295,7 +295,7 @@
       <table depends="$title5$">
         <title></title>
         <search>
-          <query>`puppet_summary_index` sourcetype="puppet:summary" pe_console="*" | stats count(metrics.changes.total) by host | rename host as Host count(metrics.changes.total) as Total</query>
+          <query>`puppet_summary_index` sourcetype="puppet:summary" pe_console="*" | stats sum(metrics.resources.total) by host | rename host as Host sum(metrics.resources.total) as Total</query>
           <earliest>$overviewTimeRange.earliest$</earliest>
           <latest>$overviewTimeRange.latest$</latest>
         </search>

--- a/default/data/ui/views/overview.xml
+++ b/default/data/ui/views/overview.xml
@@ -213,7 +213,7 @@
         </html>
       <single>
         <search>
-          <query>`puppet_summary_index` sourcetype="puppet:summary" $pe_console$ | stats count(metrics.changes.total)</query>
+          <query>`puppet_summary_index` sourcetype="puppet:summary" pe_console="*" | dedup certname | stats sum(metrics.resources.total)</query>
           <earliest>$overviewTimeRange.earliest$</earliest>
           <latest>$overviewTimeRange.latest$</latest>
         </search>


### PR DESCRIPTION
The searches that are used in the Overview tab to display resources under the "# of Resources" element and associated table currently display the number of reports.  I've update the searches for those two items to display the number of managed resources correctly.