### PR TITLE
(PIE-450) Add puppet:events_summary and puppet:activity sourcetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For detailed report generation, you will need to now install and configure the [
 
 Advanced Configuration
 ----------------
-All report views support using custom indexes for storing event data. They accomplish this with a series of advanced search macros. The queries assume each sourcetype can be stored in it's own index (facts, summary reports, detailed reports, bolt events, action events, Puppet Enterprise metrics).
+All report views support using custom indexes for storing event data. They accomplish this with a series of advanced search macros. The queries assume each sourcetype can be stored in it's own index (facts, summary reports, detailed reports, bolt events, action events, activities, Puppet Enterprise metrics).
 
 There is one top level macro, `puppet_index` which defaults to "", if you configure the HEC to use a different index and want all Puppet in that index, change that value here to be `index=puppetindexname`.
 

--- a/README/CHANGELOG.md
+++ b/README/CHANGELOG.md
@@ -1,6 +1,14 @@
 Release Notes
 ==============
 
+3.0.2:
+New Features:
+- puppet:events_summary and puppet:activity sourcetypes added.
+
+Fixes:
+- The searches that are used in the Overview tab to display resources under the "# of Resources" element and associated table used to display the number of reports. They have been corrected to display the number of resources.
+- Development workflow updated.
+
 3.0.1:
 **Breaking Changes**:
 - Alert Actions are now moved to https://github.com/puppetlabs/TA-puppet-alert-actions for better compatibility of this App for users who don't use or need the addons

--- a/README/DEVELOPING.md
+++ b/README/DEVELOPING.md
@@ -11,7 +11,7 @@ In order to load this module properly into the Splunk Add-On builder for develop
 ```
 $ git checkout -b 'my working branch'
 
-$ COPYFILE_DISABLE=1 tar -C .. --exclude=".git" --exclude="local/" --exclude="metadata/local.meta" --exclude="tmpdir" --owner=0 --group=0 --exclude=".DS_Store" --exclude=".gitignore" --exclude="default/.DS_Store" --exclude="default/data/.DS_Store" --exclude="default/data/ui/.DS_Store" --exclude=".vscode" -czvf tmpdir/TA-puppet-report-viewer.tar.gz TA-puppet-report-viewer
+$ COPYFILE_DISABLE=1 tar -C .. --exclude=".git" --exclude="local/" --exclude="metadata/local.meta" --exclude="tmpdir" --exclude=".DS_Store" --exclude=".gitignore" --exclude="default/.DS_Store" --exclude="default/data/.DS_Store" --exclude="default/data/ui/.DS_Store" --exclude=".vscode" -czvf tmpdir/TA-puppet-report-viewer.tar.gz TA-puppet-report-viewer
 
 To add your finished work back to the repo:
 - Export the build from the Splunk Add-On tool

--- a/app.manifest
+++ b/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "TA-puppet-report-viewer",
-      "version": "3.0.1"
+      "version": "3.0.2"
     },
     "author": [
       {

--- a/default/app.conf
+++ b/default/app.conf
@@ -7,7 +7,7 @@ build = 3
 
 [launcher]
 author = Puppet, Inc.
-version = 3.0.1
+version = 3.0.2
 description = Application with view Puppet data in Splunk
 
 [ui]

--- a/default/macros.conf
+++ b/default/macros.conf
@@ -33,6 +33,16 @@ iseval = 0
 definition = `puppet_index`
 iseval = 0
 
+[puppet_events_index]
+# add the name of your index here if it is not main index=puppet_index
+definition = `puppet_index`
+iseval = 0
+
+[puppet_activity_index]
+# add the name of your index here if it is not main index=puppet_index
+definition = `puppet_index`
+iseval = 0
+
 [puppet_run_index]
 # add the name of your index here if it is not main index=puppet_index
 definition = `puppet_summary_index` OR `puppet_detailed_index` OR `puppet_facts_index`

--- a/default/props.conf
+++ b/default/props.conf
@@ -52,3 +52,21 @@ TRUNCATE = 0
 category = Puppet Data
 pulldown_type = 1
 
+[puppet:events_summary]
+AUTO_KV_JSON = 0
+INDEXED_EXTRACTIONS = json
+NO_BINARY_CHECK = 1
+SHOULD_LINEMERGE = 0
+TRUNCATE = 0
+category = Puppet Data
+pulldown_type = 1
+
+[puppet:activity]
+AUTO_KV_JSON = 0
+INDEXED_EXTRACTIONS = json
+NO_BINARY_CHECK = 1
+SHOULD_LINEMERGE = 0
+TRUNCATE = 0
+category = Puppet Data
+pulldown_type = 1
+

--- a/local/app.conf
+++ b/local/app.conf
@@ -7,7 +7,7 @@ build = 4
 
 [launcher]
 author = Puppet, Inc.
-version = 3.0.1
+version = 3.0.2
 
 [ui]
 is_visible = 1

--- a/metadata/default.meta
+++ b/metadata/default.meta
@@ -42,3 +42,11 @@ owner = admin
 [macros/puppet_all_index]
 export = none
 owner = admin
+
+[macros/puppet_events_index]
+export = none
+owner = admin
+
+[macros/puppet_activity_index]
+export = none
+owner = admin


### PR DESCRIPTION
These new sourcetypes will be populated by the splunk_hec module for
events summary and activity data. They are added here so that when a
user installs the report viewer, all of the neccesary sourcetypes will
be imported along with it.