### PR TITLE
(PIE-479) Add new sourcetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For detailed report generation, you will need to now install and configure the [
 
 Advanced Configuration
 ----------------
-All report views support using custom indexes for storing event data. They accomplish this with a series of advanced search macros. The queries assume each sourcetype can be stored in it's own index (facts, summary reports, detailed reports, bolt events, action events, activities, Puppet Enterprise metrics).
+All report views support using custom indicies for storing event data. They accomplish this with a series of advanced search macros. The queries assume each sourcetype can be stored in it's own index (facts, summary reports, detailed reports, bolt events, action events, jobs, activities_rbac, activities_classifier, and Puppet Enterprise metrics).
 
 There is one top level macro, `puppet_index` which defaults to "", if you configure the HEC to use a different index and want all Puppet in that index, change that value here to be `index=puppetindexname`.
 

--- a/README/CHANGELOG.md
+++ b/README/CHANGELOG.md
@@ -1,6 +1,19 @@
 Release Notes
 ==============
 
+3.0.3:
+New Features:
+- puppet:jobs, puppet:activities_rbac, and puppet:activities_classifier sourcetypes added.
+
+Fixes:
+- Some of the panels in the Overview dashboard still contain the "X" button in the upper right to close the pop-up panel when you click on the primary panel. Some of the other panels lost the X.
+
+- Changed the drilldown to set/unset the token that shows the drilldown panel on click. Effect of the change is that clicking on the panel with the drilldown hidden shows the drilldown. Clicking on the panel with the drilldown showing hides the drilldown.
+
+- Also removed the remaining "X" buttons.
+
+- Standardize some visual formatting - moved "units" to "captions" on the images to "hosts, seconds, etc" shows up underneath the reported numbers, rather than next to them, removed odd height settings.
+
 3.0.2:
 New Features:
 - puppet:events_summary and puppet:activity sourcetypes added.

--- a/app.manifest
+++ b/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "TA-puppet-report-viewer",
-      "version": "3.0.2"
+      "version": "3.0.3"
     },
     "author": [
       {

--- a/default/app.conf
+++ b/default/app.conf
@@ -7,7 +7,7 @@ build = 3
 
 [launcher]
 author = Puppet, Inc.
-version = 3.0.2
+version = 3.0.3
 description = Application with view Puppet data in Splunk
 
 [ui]

--- a/default/macros.conf
+++ b/default/macros.conf
@@ -43,6 +43,21 @@ iseval = 0
 definition = `puppet_index`
 iseval = 0
 
+[puppet_jobs_index]
+# add the name of your index here if it is not main index=puppet_index
+definition = `puppet_index`
+iseval = 0
+
+[puppet_activities_rbac_index]
+# add the name of your index here if it is not main index=puppet_index
+definition = `puppet_index`
+iseval = 0
+
+[puppet_activities_classifier_index]
+# add the name of your index here if it is not main index=puppet_index
+definition = `puppet_index`
+iseval = 0
+
 [puppet_run_index]
 # add the name of your index here if it is not main index=puppet_index
 definition = `puppet_summary_index` OR `puppet_detailed_index` OR `puppet_facts_index`

--- a/default/props.conf
+++ b/default/props.conf
@@ -61,6 +61,33 @@ TRUNCATE = 0
 category = Puppet Data
 pulldown_type = 1
 
+[puppet:jobs]
+AUTO_KV_JSON = 0
+INDEXED_EXTRACTIONS = json
+NO_BINARY_CHECK = 1
+SHOULD_LINEMERGE = 0
+TRUNCATE = 0
+category = Puppet Data
+pulldown_type = 1
+
+[puppet:activities_rbac]
+AUTO_KV_JSON = 0
+INDEXED_EXTRACTIONS = json
+NO_BINARY_CHECK = 1
+SHOULD_LINEMERGE = 0
+TRUNCATE = 0
+category = Puppet Data
+pulldown_type = 1
+
+[puppet:activities_classifier]
+AUTO_KV_JSON = 0
+INDEXED_EXTRACTIONS = json
+NO_BINARY_CHECK = 1
+SHOULD_LINEMERGE = 0
+TRUNCATE = 0
+category = Puppet Data
+pulldown_type = 1
+
 [puppet:activity]
 AUTO_KV_JSON = 0
 INDEXED_EXTRACTIONS = json

--- a/local/app.conf
+++ b/local/app.conf
@@ -7,7 +7,7 @@ build = 4
 
 [launcher]
 author = Puppet, Inc.
-version = 3.0.2
+version = 3.0.3
 
 [ui]
 is_visible = 1

--- a/metadata/default.meta
+++ b/metadata/default.meta
@@ -50,3 +50,15 @@ owner = admin
 [macros/puppet_activity_index]
 export = none
 owner = admin
+
+[macros/puppet_jobs_index]
+export = none
+owner = admin
+
+[macros/puppet_activities_rbac_index]
+export = none
+owner = admin
+
+[macros/puppet_activities_classifier_index]
+export = none
+owner = admin


### PR DESCRIPTION
Add puppet:jobs, puppet:activities_rbac, and
puppet:activities_classifier sourcetypes to match up with changes made
to the Splunk_HEC integration.