### PR TITLE
(PIE-1124) Add source types for Puppet logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@
 1. [Description](#description)
 2. [Configuration](#configuration)
 3. [Advanced Configuration](#advanced-configuration)
-4. [Troubleshooting and Verification](#troubleshooting-and-verification)
+4. [Example Searches](#example-log-searches)
+5. [Troubleshooting and Verification](#troubleshooting-and-verification)
 
 ## Description
 
-This Splunk app provides views into the status of Puppet installations that are configured to send reports and metrics with the [`splunk_hec`](https://forge.puppet.com/puppetlabs/splunk_hec) and [`puppet_metrics_collector`](https://forge.puppet.com/puppetlabs/puppet_metrics_collector) Puppet modules.
+This Splunk app provides custom source types and views into the status of Puppet installations that are configured to send reports, facts and metrics with the [`splunk_hec`](https://forge.puppet.com/puppetlabs/splunk_hec), [`puppet_metrics_collector`](https://forge.puppet.com/puppetlabs/puppet_metrics_collector) and [`pe_status_check`](https://forge.puppet.com/puppetlabs/pe_status_check) Puppet modules.
+
+You can take action on this data by connecting a Splunk installation to the PE Orchestration service via the [Puppet Alert Orchestrator add-on for Splunk](https://splunkbase.splunk.com/app/4928/).
 
 ## Configuration
 
@@ -29,11 +32,48 @@ Create an Splunk HEC token for the app:
 
   ![hec_token](https://raw.githubusercontent.com/puppetlabs/puppetlabs-splunk_hec/main/docs/images/hec_token.png)
 
-After configuring both `splunk_hec` and the `puppet_metrics_collector` the Overview tab will start showing data from Puppet reports, while the Metrics tab will start displaying graphs related to a number of useful Puppet metrics.
+After configuring `splunk_hec`, `puppet_metrics_collector`, and `pe_status_check` the Overview tab will start showing data from Puppet reports, while the PE Metrics tab will start displaying graphs related to a number of useful Puppet metrics and results of status checks.
 
 ![Reports Overview](https://raw.githubusercontent.com/puppetlabs/TA-puppet-report-viewer/main/TA-puppet-report-viewer/readme/img/overview.png)
 
 ![Metrics](https://raw.githubusercontent.com/puppetlabs/TA-puppet-report-viewer/main/TA-puppet-report-viewer/readme/img/metrics.png)
+
+### Custom Source Types
+
+This app includes the following custom source types:
+
+  * Data from **puppetlabs-splunk_hec** module:
+    * `puppet:facts`
+    * `puppet:summary`
+  
+  * Data from **puppetlabs-puppet\_metrics\_collector** module:
+    * `puppet:metrics`
+ 
+  * Data from **puppetlabs-pe\_event\_forwarding** module:
+    * `puppet:activities_classifier`
+    * `puppet:activities_code_manager`
+    * `puppet:activities_console`
+    * `puppet:activities_rbac`
+    * `puppet:activity`
+    * `puppet:events_summary`
+    * `puppet:jobs`
+
+  * Data from **Puppet Alert Orchestrator add-on for Splunk**:
+    * `puppet:action`
+    * `puppet:bolt`
+    * `puppet:detailed`
+ 
+  * Data from Puppet infrastructure nodes via Splunk Forwarder:
+    * `puppet:service_logs`
+    * `puppet:access_logs`
+
+
+**Note**: Access and Service logs for the following Puppet services are currently supported.
+
+  * PE Console
+  * PE Orchestrator
+  * PuppetDB
+  * Puppet Server
 
 ## Advanced Configuration
 
@@ -76,11 +116,49 @@ Upon reloading the **Overview** tab in the Puppet Report Viewer app, and you sho
 `puppet_all_index` sourcetype=puppet:*
 ```
 
+## Example Log Searches
+
+### Puppet Server
+
+**Top API Calls**
+
+```
+`puppet_logs_index` sourcetype=puppet:access_logs source=*puppetserver-access.log
+| rename request as Endpoint
+| chart avg(elapsed_time) as "Time (ms)" by Endpoint
+| sort - "Time (ms)"
+```
+
+**Longest Compile Time**
+
+```
+`puppet_logs_index` sourcetype=puppet:access_logs source=*puppetserver-access.log method=POST request=/puppet/v3/catalog*
+| chart max(elapsed_time) as "Time (ms)" by client
+| sort - "Time (ms)"
+```
+
+### PuppetDB
+
+**Longest Query Time**
+
+```
+`puppet_logs_index` sourcetype=puppet:access_logs source=*puppetdb-access.log request=/pdb/query/*
+| chart max(elapsed_time) as "Time (ms)" by client
+| sort - "Time (ms)"
+```
+
+**Sync Issues**
+
+```
+`puppet_logs_index` sourcetype=puppet:service_logs service=sync log_level=WARN OR ERROR
+| chart values(message) as Message by log_level
+```
+
 ## Troubleshooting and Verification
 
 If the Puppet Report Viewer does not appear to show any data after you have followed the configuration steps for both this app and the [splunk_hec](https://github.com/puppetlabs/puppetlabs-splunk_hec) module; first check that data is being successfully sent to the Splunk server by following the [troubleshooting and verification](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/main/docs/troubleshooting_and_verification.md) steps in the `splunk_hec` documentation.
 
-If events in the `puppet:detailed` source type are not showing up in search, it means that the "Generate a Detailed Report" Alert is not configured properly with the [Puppet Alert Actions](https://splunkbase.splunk.com/app/4928/) add-on. If this Alert is enabled, and the aforementioned add-on is configured, you can view the logs with the following Splunk search:
+If events in the `puppet:detailed` source type is not showing up in search, it means that the "Generate a Detailed Report" Alert is not configured properly with the [Puppet Alert Orchestrator](https://splunkbase.splunk.com/app/4928/) add-on. If this Alert is enabled, and the aforementioned add-on is configured, you can view the logs with the following Splunk search:
 
 ```
 index=_internal sourcetype=splunkd component=sendmodalert (action="puppet_run_task_investigate" OR action="puppet_run_task" OR action="puppet_run_task_act" OR action="puppet_generate_detailed_report")

--- a/TA-puppet-report-viewer/README.md
+++ b/TA-puppet-report-viewer/README.md
@@ -5,11 +5,14 @@
 1. [Description](#description)
 2. [Configuration](#configuration)
 3. [Advanced Configuration](#advanced-configuration)
-4. [Troubleshooting and Verification](#troubleshooting-and-verification)
+4. [Example Searches](#example-log-searches)
+5. [Troubleshooting and Verification](#troubleshooting-and-verification)
 
 ## Description
 
-This Splunk app provides views into the status of Puppet installations that are configured to send reports and metrics with the [`splunk_hec`](https://forge.puppet.com/puppetlabs/splunk_hec) and [`puppet_metrics_collector`](https://forge.puppet.com/puppetlabs/puppet_metrics_collector) Puppet modules.
+This Splunk app provides custom source types and views into the status of Puppet installations that are configured to send reports, facts and metrics with the [`splunk_hec`](https://forge.puppet.com/puppetlabs/splunk_hec), [`puppet_metrics_collector`](https://forge.puppet.com/puppetlabs/puppet_metrics_collector) and [`pe_status_check`](https://forge.puppet.com/puppetlabs/pe_status_check) Puppet modules.
+
+You can take action on this data by connecting a Splunk installation to the PE Orchestration service via the [Puppet Alert Orchestrator add-on for Splunk](https://splunkbase.splunk.com/app/4928/).
 
 ## Configuration
 
@@ -29,11 +32,48 @@ Create an Splunk HEC token for the app:
 
   ![hec_token](https://raw.githubusercontent.com/puppetlabs/puppetlabs-splunk_hec/main/docs/images/hec_token.png)
 
-After configuring both `splunk_hec` and the `puppet_metrics_collector` the Overview tab will start showing data from Puppet reports, while the Metrics tab will start displaying graphs related to a number of useful Puppet metrics.
+After configuring `splunk_hec`, `puppet_metrics_collector`, and `pe_status_check` the Overview tab will start showing data from Puppet reports, while the PE Metrics tab will start displaying graphs related to a number of useful Puppet metrics and results of status checks.
 
 ![Reports Overview](https://raw.githubusercontent.com/puppetlabs/TA-puppet-report-viewer/main/TA-puppet-report-viewer/readme/img/overview.png)
 
 ![Metrics](https://raw.githubusercontent.com/puppetlabs/TA-puppet-report-viewer/main/TA-puppet-report-viewer/readme/img/metrics.png)
+
+### Custom Source Types
+
+This app includes the following custom source types:
+
+  * Data from **puppetlabs-splunk_hec** module:
+    * `puppet:facts`
+    * `puppet:summary`
+  
+  * Data from **puppetlabs-puppet\_metrics\_collector** module:
+    * `puppet:metrics`
+ 
+  * Data from **puppetlabs-pe\_event\_forwarding** module:
+    * `puppet:activities_classifier`
+    * `puppet:activities_code_manager`
+    * `puppet:activities_console`
+    * `puppet:activities_rbac`
+    * `puppet:activity`
+    * `puppet:events_summary`
+    * `puppet:jobs`
+
+  * Data from **Puppet Alert Orchestrator add-on for Splunk**:
+    * `puppet:action`
+    * `puppet:bolt`
+    * `puppet:detailed`
+ 
+  * Data from Puppet infrastructure nodes via Splunk Forwarder:
+    * `puppet:service_logs`
+    * `puppet:access_logs`
+
+
+**Note**: Access and Service logs for the following Puppet services are currently supported.
+
+  * PE Console
+  * PE Orchestrator
+  * PuppetDB
+  * Puppet Server
 
 ## Advanced Configuration
 
@@ -76,11 +116,49 @@ Upon reloading the **Overview** tab in the Puppet Report Viewer app, and you sho
 `puppet_all_index` sourcetype=puppet:*
 ```
 
+## Example Log Searches
+
+### Puppet Server
+
+**Top API Calls**
+
+```
+`puppet_logs_index` sourcetype=puppet:access_logs source=*puppetserver-access.log
+| rename request as Endpoint
+| chart avg(elapsed_time) as "Time (ms)" by Endpoint
+| sort - "Time (ms)"
+```
+
+**Longest Compile Time**
+
+```
+`puppet_logs_index` sourcetype=puppet:access_logs source=*puppetserver-access.log method=POST request=/puppet/v3/catalog*
+| chart max(elapsed_time) as "Time (ms)" by client
+| sort - "Time (ms)"
+```
+
+### PuppetDB
+
+**Longest Query Time**
+
+```
+`puppet_logs_index` sourcetype=puppet:access_logs source=*puppetdb-access.log request=/pdb/query/*
+| chart max(elapsed_time) as "Time (ms)" by client
+| sort - "Time (ms)"
+```
+
+**Sync Issues**
+
+```
+`puppet_logs_index` sourcetype=puppet:service_logs service=sync log_level=WARN OR ERROR
+| chart values(message) as Message by log_level
+```
+
 ## Troubleshooting and Verification
 
 If the Puppet Report Viewer does not appear to show any data after you have followed the configuration steps for both this app and the [splunk_hec](https://github.com/puppetlabs/puppetlabs-splunk_hec) module; first check that data is being successfully sent to the Splunk server by following the [troubleshooting and verification](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/main/docs/troubleshooting_and_verification.md) steps in the `splunk_hec` documentation.
 
-If events in the `puppet:detailed` source type are not showing up in search, it means that the "Generate a Detailed Report" Alert is not configured properly with the [Puppet Alert Actions](https://splunkbase.splunk.com/app/4928/) add-on. If this Alert is enabled, and the aforementioned add-on is configured, you can view the logs with the following Splunk search:
+If events in the `puppet:detailed` source type is not showing up in search, it means that the "Generate a Detailed Report" Alert is not configured properly with the [Puppet Alert Orchestrator](https://splunkbase.splunk.com/app/4928/) add-on. If this Alert is enabled, and the aforementioned add-on is configured, you can view the logs with the following Splunk search:
 
 ```
 index=_internal sourcetype=splunkd component=sendmodalert (action="puppet_run_task_investigate" OR action="puppet_run_task" OR action="puppet_run_task_act" OR action="puppet_generate_detailed_report")

--- a/TA-puppet-report-viewer/default/macros.conf
+++ b/TA-puppet-report-viewer/default/macros.conf
@@ -58,6 +58,11 @@ iseval = 0
 definition = `puppet_index`
 iseval = 0
 
+[puppet_logs_index]
+# add the name of your index here if it is not main index=puppet_index
+definition = `puppet_index`
+iseval = 0
+
 [puppet_run_index]
 # add the name of your index here if it is not main index=puppet_index
 definition = `puppet_summary_index` OR `puppet_detailed_index` OR `puppet_facts_index`

--- a/TA-puppet-report-viewer/default/props.conf
+++ b/TA-puppet-report-viewer/default/props.conf
@@ -101,3 +101,24 @@ SHOULD_LINEMERGE = 0
 TRUNCATE = 0
 category = Puppet Data
 pulldown_type = 1
+
+[puppet:service_logs]
+# Default
+EXTRACT-default_puppet = ^(?P<timestamp>[^ ]+)\s+(?P<log_level>\w{4,5})\s+\[(?!p\.p\.)(?P<thread>[^\]]+)\]\s+\[(?P<service>[^\]]+)\]\s+(?P<message>.+)
+# PuppetDB
+EXTRACT-puppetdb_base = ^(?P<timestamp>[^ ]+)\s+(?P<log_level>\w{4,5})\s+(?:\[)(?P<service>[a-z.-]+)(?:\])\s+(?P<message>.+)
+EXTRACT-puppetdb_gc_base = (?=[^p]*(?:p.p.c.services|p.*p.p.c.services))^[^\]\n]*\]\s+(?P<message>.+)
+EXTRACT-puppetdb = (?=[^p]*(?:p.p.command|p.*p.p.command))^(?:[^\[\n]*\[){2}(?P<thread>[^\]]+)[^\[\n]*\[(?P<elapsed_time>[^\]]+)\]\s+'(?P<command>[^']+)(?:[^ \n]* ){4,6}(?P<agent_node>.+)
+EXTRACT-puppetdb_gc = (?=[^p]*(?:p.p.c.services|p.*p.p.c.services))^[^\]\n]*\]\s+(?P<gc_status>Starting|Finished)\s+(?P<gc_action>\w+)\s+(?P<gc_message>.+)
+EXTRACT-sync_1 = (?:\[sync\])\s+(?P<sync_status>\w+)\s+(?P<table>(?=\w)[-\w]+)\s+(?:from)\s+(?P<sync_source>[a-z]+://[a-z:0-9/.-]+)
+EXTRACT-sync_2 = (?:\[sync\])\s+[^a-z]{3}\s+(?P<sync_status>\w+)\s+(?P<table>(?=\w)[-\w]+)\s+\((?P<sync_count>\d+)\)\s+(?:from)\s+(?P<sync_source>[a-z]+://[a-z:0-9/.-]+)\s+(?:in)\s+(?P<elapsed_time>\d+\s+[a-z]{2})
+EXTRACT-sync_3 = (?:\[sync\])\s+[^a-z]{3}\s+(?P<sync_status>\w+)\s+(?:with)\s+(?P<sync_source>[a-z]+://[a-z:0-9/.-]+)
+# PE Console
+EXTRACT-pe_console = ^(?P<timestamp>[^ ]+)[^\[\n]*\[(?P<thread>[^\]]+)\]\s+(?P<log_level>\w+)\s+\[(?P<service>[^\]]+)\]\s+(?P<message>.+)
+category = Puppet Data
+pulldown_type = 1
+
+[puppet:access_logs]
+EXTRACT-puppet_access = ^(?P<client>[^ ]+)[^\[\n]*\[(?P<timestamp>[^\]]+)[^ \n]* "(?P<method>[^ ]+)\s+(?P<request>[^"]+)[^"\n]*"\s+(?P<status>[^ ]+)\s+(?P<bytes_sent>[^ ]+)(?:[^ \n]* ){2}"(?P<user_agent>[^"]+)"\s+(?P<elapsed_time>\d+)\s+(?P<bytes_received>[^ ]+)
+category = Puppet Data
+pulldown_type = 1

--- a/TA-puppet-report-viewer/readme/CHANGELOG.md
+++ b/TA-puppet-report-viewer/readme/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## Version 4.0.1
+
+**New Features**:
+
+  * Adds the following custom source types for PE Console, PE Orchestrator, PuppetDB and Puppet Server logs:
+    * `puppet:access_logs`
+    * `puppet:service_logs`
+
 ## Version 4.0.0
 
 **Breaking Changes**:


### PR DESCRIPTION
# Summary

This commit adds new source types to the Report Viewer for users who are forwarding logs from Puppet infra servers.

# Detailed Description

  * Added `puppet:service_logs` and `puppet:access_logs` source types to `default/props.conf`
    * Adds a number of `EXTRACT` properties to parse Puppet logs into searchable fields.
  * Added macro for `puppet_logs_index` to `default/macros.conf` 
  * Updated `README.md` to include example Splunk searches.
  * Updated `CHANGELOG.md`.