### PR TITLE
(MAINT) Fix Alert Actions Dashboard

### DIFF
--- a/TA-puppet-report-viewer/default/data/ui/views/alert_actions.xml
+++ b/TA-puppet-report-viewer/default/data/ui/views/alert_actions.xml
@@ -15,7 +15,7 @@
       <title>Alert actions responses (if successfully run)</title>
       <table>
         <search>
-          <query>`puppet_actions_index` sourcetype="puppet:action" | eval strf_time=strftime(_time, "%Y-%m-%d %T %:z") | rename strf_time as "Time" | table Time host action_name action_state joburl message</query>
+          <query>`puppet_actions_index` sourcetype="puppet:action" action_name | eval strf_time=strftime(_time, "%Y-%m-%d %T %:z") | rename strf_time as "Time" | table Time host action_name action_state joburl message</query>
           <earliest>$boltTimeRange.earliest$</earliest>
           <latest>$boltTimeRange.latest$</latest>
         </search>

--- a/TA-puppet-report-viewer/readme/CHANGELOG.md
+++ b/TA-puppet-report-viewer/readme/CHANGELOG.md
@@ -8,6 +8,10 @@
     * `puppet:access_logs`
     * `puppet:service_logs`
 
+**Fixes**:
+
+  * Updates Alert Actions dashboard to ensure only results from triggered alert actions are displayed.
+
 ## Version 4.0.0
 
 **Breaking Changes**:


### PR DESCRIPTION
# Summary

This commit adds a fix to the alert actions dashboard to ensure only triggered actions are displayed.

# Detailed Description

  * Updated `default/data/ui/views/alert_actions.xml`.
  * Updated `CHANGELOG.md`