### PR TITLE
(PIE-1493) Splunk AppInspect update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,20 +8,26 @@ on:
 jobs:
   package-app:
     runs-on: ubuntu-latest
-    container: ghcr.io/coreymbe/splunk-appinspect:v2
+    container: ghcr.io/coreymbe/splunk-appinspect:v3
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set Version ID
         id: version-tag
-        run: echo ::set-output name=version::${GITHUB_REF#refs/*/}
+        run: echo "version=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+
+      - name: Set App Name
+        id: repo-name
+        run: |
+          repo_name=$(basename ${{ github.repository }})
+          echo "splunk_app=$repo_name" >> $GITHUB_OUTPUT
 
       - name: Build and Package App
-        run: slim package TA-puppet-report-viewer
+        run: slim package ${{ steps.repo-name.outputs.splunk_app }}
 
       - name: Upload App Build
         uses: actions/upload-artifact@v4
         with:
-          name: TA-puppet-report-viewer-${{ steps.version-tag.outputs.version }}
-          path: TA-puppet-report-viewer-*.tar.gz
+          name: ${{ steps.repo-name.outputs.splunk_app }}-${{ steps.version-tag.outputs.version }}
+          path: ${{ steps.repo-name.outputs.splunk_app }}-*.tar.gz

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -8,28 +8,31 @@ on:
 jobs:
   appinspect:
     runs-on: ubuntu-latest
-    container: ghcr.io/coreymbe/splunk-appinspect:v2
+    container: ghcr.io/coreymbe/splunk-appinspect:v3
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install JQ
-        run: apt update && apt install -y jq
+      - name: Set App Name
+        id: repo-name
+        run: |
+          repo_name=$(basename ${{ github.repository }})
+          echo "splunk_app=$repo_name" >> $GITHUB_OUTPUT
 
       - name: Run AppInspect
-        run: splunk-appinspect inspect TA-puppet-report-viewer --output-file appinspect_result.json --mode precert
+        run: splunk-appinspect inspect ${{ steps.repo-name.outputs.splunk_app }} --output-file appinspect_result.json --mode precert --included-tags cloud
 
       - name: Check AppInspect Errors
         id: appinspect-errors
         run: |
           error_check=$(jq '.summary.error' appinspect_result.json)
-          echo "::set-output name=error_count::$error_check"
+          echo "error_count=$error_check" >> $GITHUB_OUTPUT
 
       - name: Check AppInspect Failures
         id: appinspect-failures
         run: |
           fail_check=$(jq '.summary.failure' appinspect_result.json)
-          echo "::set-output name=fail_count::$fail_check"
+          echo "fail_count=$fail_check" >> $GITHUB_OUTPUT
 
       - name: AppInspect Errors
         if: ${{ steps.appinspect-errors.outputs.error_count > 0 }}
@@ -46,5 +49,5 @@ jobs:
       - name: Upload AppInspect Results
         uses: actions/upload-artifact@v4
         with:
-          name: AppInspect_TA-puppet-report-viewer
+          name: AppInspect_${{ steps.repo-name.outputs.splunk_app }}
           path: appinspect_result.json

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 
 This Splunk app provides custom source types and views into the status of Puppet installations that are configured to send reports, facts and metrics with the [`splunk_hec`](https://forge.puppet.com/puppetlabs/splunk_hec), [`puppet_metrics_collector`](https://forge.puppet.com/puppetlabs/puppet_metrics_collector) and [`pe_status_check`](https://forge.puppet.com/puppetlabs/pe_status_check) Puppet modules.
 
-You can take action on this data by connecting a Splunk installation to the PE Orchestration service via the [Puppet Alert Orchestrator add-on for Splunk](https://splunkbase.splunk.com/app/4928/).
+You can take action on this data by connecting a Splunk installation to the PE Orchestration service via the [Puppet Alert Orchestrator add-on for Splunk](https://splunkbase.splunk.com/app/7318/).
 
 ## Configuration
 
-Once the application has been installed follow the steps below to configure the [Puppet Report Viewer](https://splunkbase.splunk.com/app/4413/):
+Once the application has been installed follow the steps below to configure the [Puppet Report Viewer app for Splunk](https://splunkbase.splunk.com/app/4413/):
 
 Create an Splunk HEC token for the app:
 
@@ -158,7 +158,7 @@ Upon reloading the **Overview** tab in the Puppet Report Viewer app, and you sho
 
 If the Puppet Report Viewer does not appear to show any data after you have followed the configuration steps for both this app and the [splunk_hec](https://github.com/puppetlabs/puppetlabs-splunk_hec) module; first check that data is being successfully sent to the Splunk server by following the [troubleshooting and verification](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/main/docs/troubleshooting_and_verification.md) steps in the `splunk_hec` documentation.
 
-If events in the `puppet:detailed` source type is not showing up in search, it means that the "Generate a Detailed Report" Alert is not configured properly with the [Puppet Alert Orchestrator](https://splunkbase.splunk.com/app/4928/) add-on. If this Alert is enabled, and the aforementioned add-on is configured, you can view the logs with the following Splunk search:
+If events in the `puppet:detailed` source type is not showing up in search, it means that the "Generate a Detailed Report" Alert is not configured properly with the [Puppet Alert Orchestrator](https://splunkbase.splunk.com/app/7318/) add-on. If this Alert is enabled, and the aforementioned add-on is configured, you can view the logs with the following Splunk search:
 
 ```
 index=_internal sourcetype=splunkd component=sendmodalert (action="puppet_run_task_investigate" OR action="puppet_run_task" OR action="puppet_run_task_act" OR action="puppet_generate_detailed_report")

--- a/TA-puppet-report-viewer/README.md
+++ b/TA-puppet-report-viewer/README.md
@@ -12,11 +12,11 @@
 
 This Splunk app provides custom source types and views into the status of Puppet installations that are configured to send reports, facts and metrics with the [`splunk_hec`](https://forge.puppet.com/puppetlabs/splunk_hec), [`puppet_metrics_collector`](https://forge.puppet.com/puppetlabs/puppet_metrics_collector) and [`pe_status_check`](https://forge.puppet.com/puppetlabs/pe_status_check) Puppet modules.
 
-You can take action on this data by connecting a Splunk installation to the PE Orchestration service via the [Puppet Alert Orchestrator add-on for Splunk](https://splunkbase.splunk.com/app/4928/).
+You can take action on this data by connecting a Splunk installation to the PE Orchestration service via the [Puppet Alert Orchestrator add-on for Splunk](https://splunkbase.splunk.com/app/7318/).
 
 ## Configuration
 
-Once the application has been installed follow the steps below to configure the [Puppet Report Viewer](https://splunkbase.splunk.com/app/4413/):
+Once the application has been installed follow the steps below to configure the [Puppet Report Viewer app for Splunk](https://github.com/puppetlabs/TA-puppet-report-viewer):
 
 Create an Splunk HEC token for the app:
 
@@ -158,7 +158,7 @@ Upon reloading the **Overview** tab in the Puppet Report Viewer app, and you sho
 
 If the Puppet Report Viewer does not appear to show any data after you have followed the configuration steps for both this app and the [splunk_hec](https://github.com/puppetlabs/puppetlabs-splunk_hec) module; first check that data is being successfully sent to the Splunk server by following the [troubleshooting and verification](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/main/docs/troubleshooting_and_verification.md) steps in the `splunk_hec` documentation.
 
-If events in the `puppet:detailed` source type is not showing up in search, it means that the "Generate a Detailed Report" Alert is not configured properly with the [Puppet Alert Orchestrator](https://splunkbase.splunk.com/app/4928/) add-on. If this Alert is enabled, and the aforementioned add-on is configured, you can view the logs with the following Splunk search:
+If events in the `puppet:detailed` source type is not showing up in search, it means that the "Generate a Detailed Report" Alert is not configured properly with the [Puppet Alert Orchestrator](https://splunkbase.splunk.com/app/7318/) add-on. If this Alert is enabled, and the aforementioned add-on is configured, you can view the logs with the following Splunk search:
 
 ```
 index=_internal sourcetype=splunkd component=sendmodalert (action="puppet_run_task_investigate" OR action="puppet_run_task" OR action="puppet_run_task_act" OR action="puppet_generate_detailed_report")

--- a/TA-puppet-report-viewer/metadata/default.meta
+++ b/TA-puppet-report-viewer/metadata/default.meta
@@ -1,10 +1,10 @@
 
 []
-access = read : [ * ], write : [ admin ]
+access = read : [ * ], write : [ admin, sc_admin ]
 export = system
 
 [views]
-access = read : [ * ], write : [ admin ]
+access = read : [ * ], write : [ admin, sc_admin ]
 export = none
 
 [macros/puppet_index]

--- a/TA-puppet-report-viewer/readme/CHANGELOG.md
+++ b/TA-puppet-report-viewer/readme/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## Version 4.0.2
+
+**New Features**:
+
+**Fixes**:
+
+  * Updates Alert Actions dashboard to ensure relevant data from triggered alert action "Run a Puppet Plan" are displayed.
+
 ## Version 4.0.1
 
 **New Features**:


### PR DESCRIPTION
# Summary

This commit contains updates to utilize the latest version of Splunk AppInspect for validation. Additionally, there are some minor MAINT changes to prep for release of v4.0.2.

# Detailed Description

`.github/workflows/release.yml`
`.github/workflows/validation.yml`
  * Move to v3 of Splunk's appinspect for validation.
  * Refactor app name as a variable.

`README.md`
`TA-puppet-alert-orchestrator/readme/README.md`
  * Update Splunkbase links to new Puppet Alert Orchestrator release.

# Release Prep

`TA-puppet-report-viewer/metadata/default.meta`
  * Add `sc_admin` for compatibility with Splunk Cloud.

`TA-puppet-report-viewer/readme/CHANGELOG.md`